### PR TITLE
Make ouput available by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ EXPOSE 8332 8333
 ENTRYPOINT ["/usr/local/bin/bitcoind.sh"]
 
 # Default arguments, can be overriden
-CMD ["bitcoind", "-disablewallet"]
+CMD ["bitcoind", "-printtoconsole", "-disablewallet"]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Quick Start
         CONTAINER ID        IMAGE                       COMMAND                CREATED             STATUS              PORTS                              NAMES
         5144bdf31fa6        kylemanna/bitcoind:latest   /bitcoin/bitcoind.sh   6 seconds ago       Up 5 seconds        0.0.0.0:8333->8333/tcp, 8332/tcp   bitcoind-node
 
+4. You can then access the daemon's output thanks to the [docker logs command]( https://docs.docker.com/reference/commandline/cli/#logs) (with the container id given by `docker ps`
+
+        $ docker logs -f 5144bdf31fa6
 
 Debugging
 ---------

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Quick Start
 Debugging
 ---------
 
-    $ docker run --volumes-from=bitcoind-data --rm -it -p 8333:8333 kylemanna/bitcoind bitcoind -printtoconsole -disablewallet
     $ docker run --volumes-from=bitcoind-data --rm -it -p 8333:8333 kylemanna/bitcoind shell
 
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Quick Start
         CONTAINER ID        IMAGE                       COMMAND                CREATED             STATUS              PORTS                              NAMES
         5144bdf31fa6        kylemanna/bitcoind:latest   /bitcoin/bitcoind.sh   6 seconds ago       Up 5 seconds        0.0.0.0:8333->8333/tcp, 8332/tcp   bitcoind-node
 
-4. You can then access the daemon's output thanks to the [docker logs command]( https://docs.docker.com/reference/commandline/cli/#logs) (with the container id given by `docker ps`)
+4. You can then access the daemon's output thanks to the [docker logs command]( https://docs.docker.com/reference/commandline/cli/#logs)
 
-        $ docker logs -f 5144bdf31fa6
+        $ docker logs -f bitcoind-node
 
 Debugging
 ---------

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Quick Start
         CONTAINER ID        IMAGE                       COMMAND                CREATED             STATUS              PORTS                              NAMES
         5144bdf31fa6        kylemanna/bitcoind:latest   /bitcoin/bitcoind.sh   6 seconds ago       Up 5 seconds        0.0.0.0:8333->8333/tcp, 8332/tcp   bitcoind-node
 
-4. You can then access the daemon's output thanks to the [docker logs command]( https://docs.docker.com/reference/commandline/cli/#logs) (with the container id given by `docker ps`
+4. You can then access the daemon's output thanks to the [docker logs command]( https://docs.docker.com/reference/commandline/cli/#logs) (with the container id given by `docker ps`)
 
         $ docker logs -f 5144bdf31fa6
 


### PR DESCRIPTION
It's always useful to be able to check the output, so I added `-printconsole` to the default arguments, and updated the documentation to show how to use `docker logs`