### PR TITLE
Avoiding downloading the bootstrap file when it's not necessary

### DIFF
--- a/bin/btc_bootstrap
+++ b/bin/btc_bootstrap
@@ -2,6 +2,8 @@
 
 torrent="http://gtf.org/garzik/bitcoin/bootstrap.dat.torrent"
 
+forced=false
+
 while test $# -gt 0
 do
     case "$1" in
@@ -28,9 +30,16 @@ do
         --custom-torrent)
             torrent=$2
             ;;
+        --force)
+            forced=true
     esac
     shift
 done
+
+if [ "$forced" = false -a -e "$HOME/.bitcoin/blocks" ] ; then
+    echo "It seems you already started downloading blocks. Use the \"--force\" option if you want to download the bootstrap file anyway"
+    exit 126
+fi
 
 aria2c --dir=$HOME/.bitcoin --no-conf --file-allocation=none --follow-torrent=mem --listen-port=6881 --dht-listen-port=6882 --seed-time=0 --index-out=1=bootstrap.dat --check-integrity=true $torrent
 exit $?

--- a/bin/btc_bootstrap
+++ b/bin/btc_bootstrap
@@ -32,5 +32,5 @@ do
     shift
 done
 
-aria2c --dir=$HOME/.bitcoin --no-conf --file-allocation=none --follow-torrent=mem --listen-port=6881 --dht-listen-port=6882 --seed-time=0 --index-out=1=bootstrap.dat $torrent
+aria2c --dir=$HOME/.bitcoin --no-conf --file-allocation=none --follow-torrent=mem --listen-port=6881 --dht-listen-port=6882 --seed-time=0 --index-out=1=bootstrap.dat --check-integrity=true $torrent
 exit $?

--- a/docs/torrent_bootstrap.md
+++ b/docs/torrent_bootstrap.md
@@ -10,4 +10,5 @@ Downloading a significant portion of the Bitcoin blockchain over bittorrent save
 
 * `--gpg-check` will use the GPG signed magnet link instead of the torrent file
 * `--custom-torrent` followed by a path/URL to a torrent file or a magnet link will use it instead of default
+* `--force` will override the default behavior which avoids downloading the file if blockchain blocks have already been downloaded
 


### PR DESCRIPTION
If the bootstrap file already exists, verify its check-sum and re-download only if necessary.
See http://aria2.sourceforge.net/manual/en/html/aria2c.html#cmdoption-V

Resolves #5

Tested on my VPS