### PR TITLE
Update rpcallowip argument for bitcoin core 0.10.0

### DIFF
--- a/bin/btc_oneshot
+++ b/bin/btc_oneshot
@@ -13,7 +13,7 @@ fi
 if [ $# -gt 0 ]; then
     args=("$@")
 else
-    args=("-rpcallowip=*")
+    args=("-rpcallowip=::/0")
 fi
 
 exec bitcoind "${args[@]}"


### PR DESCRIPTION
The `rpcallowip ` option in bitcoin core 0.10.0 no longer supports string wildcard matching. Currently when running this docker-bitcoind container, I get the following error:
```
bitcoind error: Error: Invalid -rpcallowip subnet specification: *. Valid are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24).
```

This commit updates the rpcallowip option for bitcoin core 0.10.0.

Here are the bitcoin core release notes referencing the change:
https://github.com/bitcoin/bitcoin/blob/ce56f5621a94dcc2159ebe57e43da727eab18e6c/doc/release-notes/release-notes-0.10.0.md#rpc-access-control-changes