### PR TITLE
travis-ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: bash
+services: docker
+
+env:
+  - VARIANT=trusty
+
+install:
+  - git clone https://github.com/docker-library/official-images.git ~/official-images
+
+before_script:
+  - env | sort
+  - image="bitcoind:$VARIANT"
+
+script:
+  - docker build -t "$image" .
+  - ~/official-images/test/run.sh "$image"
+
+after_script:
+  - docker images
+
+# vim:set et ts=2 sw=2:


### PR DESCRIPTION
This adds a basic travis-ci testing support for this repository. It is based on a code from official docker images, like https://github.com/docker-library/memcached and https://github.com/docker-library/mysql.