### PR TITLE
[critical]: fix password generation

### DIFF
--- a/bin/btc_init
+++ b/bin/btc_init
@@ -14,7 +14,7 @@ if [ ! -e "$HOME/.bitcoin/bitcoin.conf" ]; then
 disablewallet=${DISABLEWALLET:-1}
 printtoconsole=${PRINTTOCONSOLE:-1}
 rpcuser=${RPCUSER:-bitcoinrpc}
-rpcpassword=${RPCPASSWORD:-dd if=/dev/urandom bs=33 count=1 status=none | base64}
+rpcpassword=${RPCPASSWORD:-`dd if=/dev/urandom bs=33 count=1 2>/dev/null | base64`}
 EOF
 
 fi


### PR DESCRIPTION
This one is ugly: It causes the generated password to be a default one of

`dd if=/dev/urandom bs=33 count=1 status=none | base64`

instead of a random one.

Testcase:

```
$ docker run --name=bitcoind-node -d kylemanna/bitcoind
$ docker exec -it bitcoind-node /bin/bash -c "cat /bitcoin/.bitcoin/bitcoin.conf"
```

Result:

```
[...]
rpcuser=bitcoinrpc
rpcpassword=dd if=/dev/urandom bs=33 count=1 status=none | base64
$
```

Expected result: A random string...

This is caused by the substitution not being evaluated, e.g.:

```
ubuntu@test:~$ echo "rpcpassword = ${RPCPASSWORD:-dd if=/dev/urandom bs=33 count=1 status=none | base64}"
rpcpassword = dd if=/dev/urandom bs=33 count=1 status=none | base64
```

What you want instead is

```
ubuntu@test:~$ echo "rpcpassword = ${RPCPASSWORD:-`dd if=/dev/urandom bs=33 count=1 2>/dev/null | base64`}"
rpcpassword = xjfh580Z0uIrXd+7bIKv9JdYz3c0vmcOuh9jIQ5DNmYp
```