### PR TITLE
Enforce the full OpenPGP fingerprint of ppa:bitcoin/bitcoin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV GROUP_ID ${GROUP_ID:-1000}
 RUN groupadd -g ${GROUP_ID} bitcoin \
 	&& useradd -u ${USER_ID} -g bitcoin -s /bin/bash -m -d /bitcoin bitcoin
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8842ce5e && \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C70EF1F0305A1ADB9986DBD8D46F45428842CE5E && \
     echo "deb http://ppa.launchpad.net/bitcoin/bitcoin/ubuntu xenial main" > /etc/apt/sources.list.d/bitcoin.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Previously, basically anyone in the position to MITM the network connection of the build server for this image could have easily compromised it!

@kylemanna Seems you like to live dangerously?

Ref: https://www.phoronix.com/scan.php?page=news_item&px=Short-PGP-Collision-Attacks