### PR TITLE
Specify the bitcoind version to install to make it easier to update the image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C70EF1F0305A1ADB998
     echo "deb http://ppa.launchpad.net/bitcoin/bitcoin/ubuntu xenial main" > /etc/apt/sources.list.d/bitcoin.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		bitcoind \
+		bitcoind=0.18.0-xenial1 \
 	&& apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # grab gosu for easy step-down from root


### PR DESCRIPTION
I noticed that docker would only update the bitcoin release when I told it to rebuild from scratch, specifying the version allows docker caching to work properly. As an added bonus it makes it easier to understand which version you'll get when using this image.