### PR TITLE
Update to use upstream bitcoind v0.20.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,54 +1,53 @@
-FROM ubuntu:xenial
-MAINTAINER Kyle Manna <kyle@kylemanna.com>
+# Smallest base image, latests stable image
+# Alpine would be nice, but it's linked again musl and breaks the bitcoin core download binary
+#FROM alpine:latest
+FROM ubuntu:latest
 
-ARG USER_ID
-ARG GROUP_ID
+LABEL maintainer="Kyle Manna <kyle@kylemanna.com>"
 
-ENV HOME /bitcoin
-
-# add user with specified (or default) user/group ids
-ENV USER_ID ${USER_ID:-1000}
-ENV GROUP_ID ${GROUP_ID:-1000}
-
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -g ${GROUP_ID} bitcoin \
-	&& useradd -u ${USER_ID} -g bitcoin -s /bin/bash -m -d /bitcoin bitcoin
-
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C70EF1F0305A1ADB9986DBD8D46F45428842CE5E && \
-    echo "deb http://ppa.launchpad.net/bitcoin/bitcoin/ubuntu xenial main" > /etc/apt/sources.list.d/bitcoin.list
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		bitcoind \
-	&& apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# grab gosu for easy step-down from root
-ENV GOSU_VERSION 1.7
-RUN set -x \
-	&& apt-get update && apt-get install -y --no-install-recommends \
-		ca-certificates \
-		wget \
-	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu \
-	&& gosu nobody true \
-	&& apt-get purge -y \
-		ca-certificates \
-		wget \
-	&& apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-ADD ./bin /usr/local/bin
-
+EXPOSE 8332 8333
 VOLUME ["/bitcoin"]
 
-EXPOSE 8332 8333 18332 18333
+ENTRYPOINT ["docker-entrypoint.sh"]
+ENV HOME /bitcoin
+
+ARG GROUP_ID=1000
+ARG USER_ID=1000
+RUN groupadd -g ${GROUP_ID} bitcoin \
+    && useradd -u ${USER_ID} -g bitcoin -d /bitcoin bitcoin
+
+# Testing: gosu
+#RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories \
+#    && apk add --update --no-cache gnupg gosu gcompat libgcc
+RUN apt update \
+    && apt install -y --no-install-recommends \
+        ca-certificates \
+        gosu \
+        wget \
+        gnupg \
+    && apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ARG VERSION=0.20.1
+ARG ARCH=x86_64
+ARG BITCOIN_CORE_SIGNATURE=01EA5486DE18A882D4C2684590C8019E36C2E964
+
+# Don't use base image's bitcoin package for a few reasons:
+# 1. Would need to use ppa/latest repo for the latest release.
+# 2. Some package generates /etc/bitcoin.conf on install and that's dangerous to bake in with Docker Hub.
+# 3. Verifying pkg signature from main website should inspire confidence and reduce chance of surprises.
+# Instead fetch, verify, and extract to Docker image
+RUN cd /tmp \
+    && wget https://bitcoincore.org/bin/bitcoin-core-${VERSION}/SHA256SUMS.asc \
+    && gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys ${BITCOIN_CORE_SIGNATURE} \
+    && gpg --verify SHA256SUMS.asc \
+    && grep bitcoin-${VERSION}-${ARCH}-linux-gnu.tar.gz SHA256SUMS.asc > SHA25SUM \
+    && wget https://bitcoincore.org/bin/bitcoin-core-0.20.1/bitcoin-${VERSION}-${ARCH}-linux-gnu.tar.gz \
+    && sha256sum -c SHA25SUM \
+    && tar -xzvf bitcoin-${VERSION}-${ARCH}-linux-gnu.tar.gz -C /opt \
+    && ln -sv bitcoin-${VERSION} /opt/bitcoin \
+    && ln -sv /opt/bitcoin/bin/* /usr/local/bin
+
+ADD ./bin docker-entrypoint.sh /usr/local/bin/
 
 WORKDIR /bitcoin
-
-COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
-
 CMD ["btc_oneshot"]

--- a/bin/btc_oneshot
+++ b/bin/btc_oneshot
@@ -1,14 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 
 set -ex
 
 # Generate bitcoin.conf
 btc_init
 
-if [ $# -gt 0 ]; then
-    args=("$@")
-else
-    args=("-rpcallowip=::/0")
+# Default / no argument invocation listens for RPC commands and has to accept non-localhost because of
+# docker port proxying or docker private networking.
+if [ $# -eq 0 ]; then
+    set -- "-rpcbind=" "-rpcallowip=::/0"
 fi
 
-exec bitcoind "${args[@]}"
+exec bitcoind "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,11 +7,12 @@ if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
 	set -- btc_oneshot "$@"
 fi
 
-# allow the container to be started with `--user`
+# Allow the container to be started with `--user`, if running as root drop privileges
 if [ "$1" = 'btc_oneshot' -a "$(id -u)" = '0' ]; then
 	chown -R bitcoin .
 	exec gosu bitcoin "$0" "$@"
 fi
 
+# If not root (i.e. docker run --user $USER ...), then run as invoked
 exec "$@"
 


### PR DESCRIPTION
* Update to use upstream packaged binary distribution instead of Ubuntu PPA which has been abandoned.
* Clean things up slightly.
* Fix RPC bug.
* Improve script compatibility with standard POSIX compliant shells.
* Closes #62 and #66 
