### PR TITLE
Remove /bitcoin volume declaration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ LABEL maintainer="Kyle Manna <kyle@kylemanna.com>"
 ENTRYPOINT ["docker-entrypoint.sh"]
 ENV HOME /bitcoin
 EXPOSE 8332 8333
-VOLUME ["/bitcoin/.bitcoin"]
 WORKDIR /bitcoin
 
 ARG GROUP_ID=1000


### PR DESCRIPTION
I suggest removing the volume declaration from the Dockerfile.  With this line in the Dockerfile, users cannot mount host paths into `/bitcoin` (because it is a volume).

If the line is not present in the Dockerfile, users are free to declare a Docker volume themselves at runtime and mount it into the container.

Arguments against this PR: I can understand the motivation for declaring a volume because it allows a user to run this image with defaults and get data permanence automatically (as Docker should create a volume for the data automatically).  ~~Additionally, just mounting the data anywhere else and setting $HOME to that location avoids this change entirely.  If this PR is rejected, I can submit an alternate PR that calls out this conflict in the README so that users who don't use Docker volumes don't scratch their heads for a few minutes like I did after updating.~~

EDIT: Turns out, just setting $HOME isn't good enough, I had to change my command to `sh -c 'usermod -d [different folder] bitcoin && btc_oneshot [arguments]`.  Changes are required to support the use case of using something other than a Docker volume for `/bitcoin` natively.