### PR TITLE
Volume declaration changes reflected in documentation (fixes issue #74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Quick Start
 1. Create a `bitcoind-data` volume to persist the bitcoind blockchain data, should exit immediately.  The `bitcoind-data` container will store the blockchain when the node container is recreated (software upgrade, reboot, etc):
 
         docker volume create --name=bitcoind-data
-        docker run -v bitcoind-data:/bitcoin --name=bitcoind-node -d \
+        docker run -v bitcoind-data:/bitcoin/.bitcoin --name=bitcoind-node -d \
             -p 8333:8333 \
             -p 127.0.0.1:8332:8332 \
             kylemanna/bitcoind

--- a/docs/config.md
+++ b/docs/config.md
@@ -3,7 +3,7 @@ bitcoind config tuning
 
 You can use environment variables to customize config ([see docker run environment options](https://docs.docker.com/engine/reference/run/#/env-environment-variables)):
 
-        docker run -v bitcoind-data:/bitcoin --name=bitcoind-node -d \
+        docker run -v bitcoind-data:/bitcoin/.bitcoin --name=bitcoind-node -d \
             -p 8333:8333 \
             -p 127.0.0.1:8332:8332 \
             -e DISABLEWALLET=1 \
@@ -14,7 +14,7 @@ You can use environment variables to customize config ([see docker run environme
 
 Or you can use your very own config file like that:
 
-        docker run -v bitcoind-data:/bitcoin --name=bitcoind-node -d \
+        docker run -v bitcoind-data:/bitcoin/.bitcoin --name=bitcoind-node -d \
             -p 8333:8333 \
             -p 127.0.0.1:8332:8332 \
             -v /etc/mybitcoin.conf:/bitcoin/.bitcoin/bitcoin.conf \


### PR DESCRIPTION
Documentation now shows example configurations using /bitcoin/.bitcoin (instead of /bitcoin) volume mount point