### PR TITLE
fix: broken URL to SubmittingPatches page on kernel.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ The style of the repo follows that of the Linux kernel, in particular:
 * More details in the body
 * Match surrounding coding style (line wrapping, spaces, etc)
 
-More details in the [SubmittingPatches](https://www.kernel.org/doc/Documentation/SubmittingPatches) document included with the Linux kernel.  In particular the following sections:
+More details in the [SubmittingPatches](https://www.kernel.org/doc/Documentation/process/submitting-patches.rst) document included with the Linux kernel.  In particular the following sections:
 
 * `2) Describe your changes`
 * `3) Separate your changes`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ The style of the repo follows that of the Linux kernel, in particular:
 * More details in the body
 * Match surrounding coding style (line wrapping, spaces, etc)
 
-More details in the [SubmittingPatches](https://www.kernel.org/doc/Documentation/process/submitting-patches.rst) document included with the Linux kernel.  In particular the following sections:
+More details in the [SubmittingPatches](https://www.kernel.org/doc/html/latest/process/submitting-patches.html) document included with the Linux kernel.  In particular the following sections:
 
 * `2) Describe your changes`
 * `3) Separate your changes`


### PR DESCRIPTION
Hi! I noticed that the page referenced in CONTRIBUTING.md has moved with the following message when you hit the page:

`This file has moved to process/submitting-patches.rst`

So I updated the URL accordingly.