### PR TITLE
Add Regtest parameter

### DIFF
--- a/bin/btc_init
+++ b/bin/btc_init
@@ -11,6 +11,7 @@ if [ ! -e "$HOME/.bitcoin/bitcoin.conf" ]; then
 
     # Seed a random password for JSON RPC server
     cat <<EOF > $HOME/.bitcoin/bitcoin.conf
+regtest=${REGTEST:0}
 disablewallet=${DISABLEWALLET:-1}
 printtoconsole=${PRINTTOCONSOLE:-1}
 rpcuser=${RPCUSER:-bitcoinrpc}

--- a/bin/btc_init
+++ b/bin/btc_init
@@ -11,7 +11,7 @@ if [ ! -e "$HOME/.bitcoin/bitcoin.conf" ]; then
 
     # Seed a random password for JSON RPC server
     cat <<EOF > $HOME/.bitcoin/bitcoin.conf
-regtest=${REGTEST:0}
+regtest=${REGTEST:-0}
 disablewallet=${DISABLEWALLET:-1}
 printtoconsole=${PRINTTOCONSOLE:-1}
 rpcuser=${RPCUSER:-bitcoinrpc}

--- a/docs/config.md
+++ b/docs/config.md
@@ -6,7 +6,7 @@ You can use environment variables to customize config ([see docker run environme
         docker run -v bitcoind-data:/bitcoin/.bitcoin --name=bitcoind-node -d \
             -p 8333:8333 \
             -p 127.0.0.1:8332:8332 \
-            -e REGTEST=1
+            -e REGTEST=1 \
             -e DISABLEWALLET=1 \
             -e PRINTTOCONSOLE=1 \
             -e RPCUSER=mysecretrpcuser \

--- a/docs/config.md
+++ b/docs/config.md
@@ -6,6 +6,7 @@ You can use environment variables to customize config ([see docker run environme
         docker run -v bitcoind-data:/bitcoin/.bitcoin --name=bitcoind-node -d \
             -p 8333:8333 \
             -p 127.0.0.1:8332:8332 \
+            -e REGTEST=1
             -e DISABLEWALLET=1 \
             -e PRINTTOCONSOLE=1 \
             -e RPCUSER=mysecretrpcuser \

--- a/docs/config.md
+++ b/docs/config.md
@@ -6,7 +6,7 @@ You can use environment variables to customize config ([see docker run environme
         docker run -v bitcoind-data:/bitcoin/.bitcoin --name=bitcoind-node -d \
             -p 8333:8333 \
             -p 127.0.0.1:8332:8332 \
-            -e REGTEST=1 \
+            -e REGTEST=0 \
             -e DISABLEWALLET=1 \
             -e PRINTTOCONSOLE=1 \
             -e RPCUSER=mysecretrpcuser \


### PR DESCRIPTION
Hi There,

Please find attached PR to add a `REGTEST` environment variable to configure regtest mode for easier local development.

We have found it much simpler to configure a development config using docker compose without needing to maintain an extra `bitcoin.conf` file for changing core functions of bitcoind.

Please let me know what you think