### PR TITLE
Build image for amd64, arm64 and riscv64 (Issue #85)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - image="bitcoind:$VARIANT"
 
 script:
-  - docker build -t "$image" .
+  - docker buildx build --platform linux/arm64,linux/amd64,linux/riscv64 -t "$image" .
   - official-images/test/run.sh "$image"
   - test/run.sh "$image"
 


### PR DESCRIPTION
This pull requests adds multiarch setup to the Dockerfile. The image is built for amd64, arm64 and riscv64.

In order to build it locally you might have to setup a multiarch environment:

``` bash 
$ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
$ docker buildx create --name multiarch --driver docker-container --use
$ docker buildx inspect --bootstrap
```