### PR TITLE
Bump to v26.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt update \
     wget \
     && apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ARG VERSION=26.0
+ARG VERSION=26.1
 ARG BITCOIN_CORE_SIGNATURE=71A3B16735405025D447E8F274810B012346C9A6
 
 # Don't use base image's bitcoin package for a few reasons:


### PR DESCRIPTION
Tested and working perfectly in https://github.com/sethforprivacy/docker-bitcoind/commit/26f102a3d13124f2da6ea0f139a3964f6feb53f5 on multiple servers.