### PR TITLE
Fix Ubuntu 24.04 base image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,8 @@ WORKDIR /bitcoin
 
 ARG GROUP_ID=1000
 ARG USER_ID=1000
-RUN groupadd -g ${GROUP_ID} bitcoin \
+RUN userdel ubuntu \
+    && groupadd -g ${GROUP_ID} bitcoin \
     && useradd -u ${USER_ID} -g bitcoin -d /bitcoin bitcoin
 
 COPY --from=build /opt/ /opt/


### PR DESCRIPTION
Ubuntu 23.04+ introduced a change that creates a default `ubuntu` user with the UID/GID we use for the `bitcoin` user.

In order to not break current permissions this simply deletes the default user and creates the `bitcoin` user as we always have.