### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 ------------
 
 * Physical machine, cloud instance, or VPS that supports Docker (i.e. [Vultr](http://bit.ly/1HngXg0), [Digital Ocean](http://bit.ly/18AykdD), KVM or XEN based VMs) running Ubuntu 14.04 or later (*not OpenVZ containers!*)
-* At least 500 GB to store the block chain files (and always growing!)
+* At least 700 GB to store the block chain files (and always growing!)
 * At least 1 GB RAM + 2 GB swap file
 
 Recommended and tested on unadvertised (only shown within control panel) [Vultr SATA Storage 1024 MB RAM/250 GB disk instance @ $10/mo](http://bit.ly/vultrbitcoind).  Vultr also *accepts Bitcoin payments*!
@@ -43,7 +43,7 @@ Quick Start
         CONTAINER ID        IMAGE                         COMMAND             CREATED             STATUS              PORTS                                              NAMES
         d0e1076b2dca        kylemanna/bitcoind:latest     "btc_oneshot"       2 seconds ago       Up 1 seconds        127.0.0.1:8332->8332/tcp, 0.0.0.0:8333->8333/tcp   bitcoind-node
 
-3. You can then access the daemon's output thanks to the [docker logs command]( https://docs.docker.com/reference/commandline/cli/#logs)
+3. You can then access the daemon's output thanks to the [docker logs command](https://docs.docker.com/reference/cli/docker/service/logs/)
 
         docker logs -f bitcoind-node
 


### PR DESCRIPTION
- The URL link to the docker logs CLI reference has been moved.
- Blockchain disk requirements have increased beyond 500GB (currently 690GB).