### PR TITLE
Update to Bitcoin Core 30.2 and update location of test_bitcoin binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN apt update \
     wget \
     && apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ARG VERSION=29.1
-ARG BITCOIN_CORE_SIGNATURE=71A3B16735405025D447E8F274810B012346C9A6
+ARG VERSION=30.2
+ARG BITCOIN_CORE_SIGNATURE=E777299FC265DD04793070EB944D35F9AC3DB76A
 
 # Don't use base image's bitcoin package for a few reasons:
 # 1. Would need to use ppa/latest repo for the latest release.
@@ -42,8 +42,8 @@ RUN cd /tmp \
     && sha256sum --ignore-missing --check SHA256SUMS \
     && tar -xzvf bitcoin-${VERSION}-${ARCH}-linux-gnu.tar.gz -C /opt \
     && ln -sv bitcoin-${VERSION} /opt/bitcoin \
-    && /opt/bitcoin/bin/test_bitcoin --show_progress \
-    && rm -v /opt/bitcoin/bin/test_bitcoin /opt/bitcoin/bin/bitcoin-qt
+    && /opt/bitcoin/libexec/test_bitcoin --show_progress \
+    && rm -v /opt/bitcoin/libexec/test_bitcoin /opt/bitcoin/bin/bitcoin-qt
 
 FROM ubuntu:latest
 LABEL maintainer="Kyle Manna <kyle@kylemanna.com>"


### PR DESCRIPTION
Updates the Dockerfile so we can:

* Use version 30.2 (updates signature key to Michael Ford @fanquake)
* Find the new location of test_bitcoin